### PR TITLE
Setup CI for common and Android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+os:
+  - osx
 language: android
-dist: trusty
 android:
   components:
     - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_script:
     - chmod +x gradlew
 
 script:
-    - ./gradlew common:build
-    - ./gradlew app:testDebugUnitTest app:assembleDebug
+    - ./gradlew common:build --console plain
+    - ./gradlew app:testDebugUnitTest app:assembleDebug --console plain
 
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
     - touch ~/.android/repositories.cfg
     - export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'
     - sdkmanager --update
-    - sdkmanager "platform-tools" "platforms;android-28"
+    - yes | sdkmanager "platform-tools" "platforms;android-28"
     - chmod +x gradlew
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 os:
   - osx
-language: android
-android:
-  components:
-    - tools
-    - platform-tools
-    - tools
-    - build-tools-28.0.3
-    - android-28
+language: swift
 
 before_script:
+    - brew cask install adoptopenjdk8
+    - brew cask install android-sdk
+    - echo "export ANDROID_HOME=/usr/local/share/android-sdk" >> ~/.bash_profile
+    - source ~/.bash_profile
+    - touch ~/.android/repositories.cfg
+    - sdkmanager --update
+    - sdkmanager "platform-tools" "platforms;android-28"
     - chmod +x gradlew
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
     - touch ~/.android/repositories.cfg
     - export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'
     - sdkmanager --update
-    - yes | sdkmanager "platform-tools" "platforms;android-28"
+    - yes | sdkmanager "platform-tools" "platforms;android-28" > /dev/null
     - chmod +x gradlew
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: android
+dist: trusty
+android:
+  components:
+    - tools
+    - platform-tools
+    - tools
+    - build-tools-28.0.3
+    - android-28
+
+before_script:
+    - chmod +x gradlew
+
+script:
+    - ./gradlew common:build
+    - ./gradlew app:testDebugUnitTest app:assembleDebug
+
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
     - echo "export ANDROID_HOME=/usr/local/share/android-sdk" >> ~/.bash_profile
     - source ~/.bash_profile
     - touch ~/.android/repositories.cfg
+    - export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions --add-modules java.se.ee'
     - sdkmanager --update
     - sdkmanager "platform-tools" "platforms;android-28"
     - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
 language: swift
 
 before_script:
+    - brew tap AdoptOpenJDK/openjdk
     - brew cask install adoptopenjdk8
     - brew cask install android-sdk
     - echo "export ANDROID_HOME=/usr/local/share/android-sdk" >> ~/.bash_profile


### PR DESCRIPTION
Build just common and android at the moment, but on mac **os x** so that we can add ios build later.

Android is not officially supported on mac os by Travis, so java and android SDK are installed manually.

Solves https://github.com/dcampogiani/ktmp/issues/3